### PR TITLE
feat(pool): Add Close method to Client

### DIFF
--- a/chpool/client.go
+++ b/chpool/client.go
@@ -39,6 +39,19 @@ func (c *Client) Ping(ctx context.Context) error {
 	return c.client().Ping(ctx)
 }
 
+func (c *Client) Close() error {
+	var err error
+
+	client := c.client()
+	if !client.IsClosed() {
+		err = client.Close()
+	}
+
+	c.res.Destroy()
+
+	return err
+}
+
 func (c *Client) client() *ch.Client {
 	return c.res.Value().client
 }

--- a/chpool/client_test.go
+++ b/chpool/client_test.go
@@ -27,3 +27,14 @@ func TestClient_Ping(t *testing.T) {
 
 	require.NoError(t, conn.Ping(context.Background()))
 }
+
+func TestClient_Close(t *testing.T) {
+	t.Parallel()
+	p := PoolConn(t)
+	conn, err := p.Acquire(context.Background())
+	require.NoError(t, err)
+
+	err = conn.Close()
+	require.NoError(t, err)
+	require.True(t, conn.client().IsClosed())
+}


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
This adds a `Close` method to the chpool.Client struct. This function will close the underlying connection and destroy the resource from the pool.

This will allow broken connections to not be put back into the pool if they are broken. The snipped below exemplifies the scenario.

```go
conn, err := pool.Acquire(ctx)
if err != nil {
	return nil, err
}

if err := conn.Ping(ctx); err != nil {
	conn.Close() <<<<< This connections is broken and should not be put back into the pool using conn.Release()
	return nil, level.Error(logger).Log("msg", "failed to ping acquired connection from pool", "err", err)
}

return conn, nil
```

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
